### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -523,10 +523,12 @@ def check_plex_pin(pin_id):
     has_access, error_msg = PlexAPI.verify_library_access(settings.plex_url, auth_token)
     
     if not has_access:
+        # Optionally log the detailed error_msg for server-side debugging
+        logger.warning(f"User library access failed: {error_msg}")
         return jsonify({
             'success': False,
             'status': 'no_library_access',
-            'message': f'You do not have access to this Plex server. {error_msg or ""}'
+            'message': 'You do not have access to this Plex server.'
         })
     
     # Smart merge logic: plex_id → email → create new


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/2](https://github.com/netpersona/Popcorn/security/code-scanning/2)

To fix this issue, you should suppress the actual exception details from user-facing responses in the `check_plex_pin` function in `app.py`. Instead, respond with a generic error message (such as "Unable to verify access to Plex server") while retaining the detailed log for internal use. 

**Steps to implement:**
- Change the return value in `check_plex_pin` (app.py, line 526) so that the `'message'` field contains only a generic user message, not the raw `error_msg` as returned from `plex_api.py`.
- Optionally, you may still log or audit `error_msg` for diagnosis, but do not send it in the response.
- No changes are necessary in `plex_api.py` unless you want to further clean up the separation between internal and external messaging, but the critical change is in `app.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
