### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/theme_service.py
+++ b/theme_service.py
@@ -181,7 +181,7 @@ class ThemeService:
         except Exception as e:
             session.rollback()
             logger.error(f"Failed to delete custom theme: {e}")
-            return False, str(e)
+            return False, "An internal error occurred while deleting the theme."
         finally:
             session.close()
     


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/10](https://github.com/netpersona/Popcorn/security/code-scanning/10)

To fix this problem, we should ensure the details of exception messages are not exposed to external users in API responses. Instead, the detailed error should be logged server-side for internal review, and the user should receive a generic error message. In `theme_service.py`, the exceptions caught in `delete_custom_theme` and (optionally) elsewhere should be logged, and only a generic error message returned to the caller. Then in `app.py`, the frontend response to failure receives only the generic message. Specifically:

- In `theme_service.py`, on line 184, change `return False, str(e)` to return `return False, "An internal error occurred while deleting the theme."` (and log `e` as already done).
- This ensures only the generic message can be returned to the user via the API in `app.py` line 1361.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
