### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1088,9 +1088,10 @@ def test_plex_connection():
             'message': f'Successfully connected to: {server_name}'
         })
     except Exception as e:
+        logging.exception(f'Error testing Plex connection for user {current_user.id}')
         return jsonify({
             'success': False,
-            'message': f'Connection failed: {str(e)}'
+            'message': 'Connection failed: An internal error occurred.'
         })
 
 @app.route('/api/clients')


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/5](https://github.com/netpersona/Popcorn/security/code-scanning/5)

To fix the information exposure issue, modify the `except` block in the `/settings/test-plex` endpoint so that instead of returning the exception’s message to the client, it logs the full exception (ideally with stack trace) to the server, and returns a generic error message in the response. This ensures that administrators can still diagnose issues via the logs, but sensitive details are not revealed to end users. The changes are limited to function `test_plex_connection`, lines 1090–1094. Logging should use the existing `logging` module (already imported). No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
