### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/plex_api.py
+++ b/plex_api.py
@@ -141,8 +141,8 @@ class PlexAPI:
                     client.playMedia(movie)
                     logger.info(f"Sent playMedia command to {client.title}")
                 except Exception as e:
-                    logger.error(f"Failed to start playback: {e}")
-                    return False, f"Playback failed: {str(e)}. Make sure your Plex client is responding.", 0
+                    logger.error(f"Failed to start playback: {e}", exc_info=True)
+                    return False, "Playback failed. Please check your Plex client and try again.", 0
                 
                 if offset_ms > 0:
                     import time


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/4](https://github.com/netpersona/Popcorn/security/code-scanning/4)

To resolve this vulnerability, all exception messages or raw exception stringifications returned to external users should be replaced with a generic error message, such as "Playback failed. Please check your Plex client and try again." The full details of the exception, including the stack trace and any sensitive context, should instead be logged server-side (using `logger.error()`). 

Specifically, in `plex_api.py`:
- In the `except Exception as e:` block at line 143, currently the exception message is included in the return value, which ultimately reaches the user.
- Change this so that the logging statement is retained for diagnostics, but the returned error message is generic and does not reveal internal details.

No additional external dependencies are required, and imports remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
