### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1130,7 +1130,7 @@ def get_clients():
         return jsonify({'success': True, 'clients': clients})
     except Exception as e:
         logger.error(f"Error getting clients: {e}", exc_info=True)
-        return jsonify({'success': False, 'clients': [], 'error': str(e)})
+        return jsonify({'success': False, 'clients': [], 'error': 'An internal server error occurred.'})
 
 @app.route('/api/devices', methods=['GET'])
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/11](https://github.com/netpersona/Popcorn/security/code-scanning/11)

To fix this vulnerability, do not expose the exception message in the response sent to the user. Instead, log the detailed error (including stack trace if desired) on the server, and return a generic error message in the JSON response. You should replace the `'error': str(e)` value in the `jsonify` response with a generic message such as "An internal server error occurred." For logging, you can use the built-in Python logging module to record both the exception string and its stack trace (using `logger.error(..., exc_info=True)`). You should perform these changes in the code block for the `/api/clients` route in app.py.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
