### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/plex_api.py
+++ b/plex_api.py
@@ -323,4 +323,5 @@ class PlexAPI:
             
         except Exception as e:
             logger.error(f"Failed to verify library access: {e}")
-            return False, f"Cannot access Plex server: {str(e)}"
+            # Return a generic error message to the client to avoid leaking internal details
+            return False, "Cannot access Plex server at this time. Please try again later or contact your administrator."


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/2](https://github.com/netpersona/Popcorn/security/code-scanning/2)

To fix the information exposure through an exception, we need to ensure that error messages sent to external users do not include raw exception details, such as stack traces or internal system information. This is particularly relevant in `plex_api.py` in the `verify_library_access` method, where the error message currently includes `str(e)`. Instead, exception details should be logged server-side for debugging, while the API returns a generic error message to the client.  

**Changes needed:**
- In `plex_api.py`, within `verify_library_access`, replace the returned error message (via the `error_msg` variable) so that it is a generic, non-sensitive message.
- Retain logging of the actual exception (`e`) for server-side review.
- Ensure the return to callers/users only contains a generic description.
- No changes are required in `app.py` since it correctly passes along any error message from the API result.

_No additional imports are needed, as the necessary `logging` infrastructure is already present._

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
