### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1110,9 +1110,10 @@ def test_plex_connection():
             'message': f'Successfully connected to: {server_name}'
         })
     except Exception as e:
+        logger.error(f"Error testing Plex connection: {e}", exc_info=True)
         return jsonify({
             'success': False,
-            'message': f'Connection failed: {str(e)}'
+            'message': 'Connection failed: An internal error occurred while testing the Plex connection.'
         })
 
 @app.route('/api/clients')


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/5](https://github.com/netpersona/Popcorn/security/code-scanning/5)

The correct way to fix this issue is to avoid returning the exception message to the user. Instead, log the detailed exception (including the stack trace) on the server using the application's logger, and return a generic error message to the client. The function already imports `logging`, so you can leverage `logging.getLogger(__name__)` or, if there is an existing logger (such as `logger` elsewhere in the code), use it to log the exception details along with `exc_info=True` for the stack trace.

Modify the `except` block inside the `test_plex_connection` route to:
- Log the error and the stack trace.
- Return a generic message to the client in the `'message'` field.

All edits should be within `app.py`, specifically within the `test_plex_connection` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
