### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1466,7 +1466,8 @@ def upload_theme():
     try:
         theme_json = file.read().decode('utf-8')
     except Exception as e:
-        return jsonify({'success': False, 'message': f'Failed to read file: {str(e)}'}), 400
+        logging.exception("Failed to read uploaded theme file")
+        return jsonify({'success': False, 'message': 'Failed to read file.'}), 400
     
     from theme_service import ThemeService
     is_public = request.form.get('is_public') == 'true' if current_user.is_admin else False


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/7](https://github.com/netpersona/Popcorn/security/code-scanning/7)

To fix the information exposure vulnerability, replace the specific exception message with a generic error message in the API response. Log the real exception details on the server side (using the standard Python `logging` module, which is already imported in the code). This change should be applied only to the `except Exception as e:` block inside the `upload_theme` endpoint in `app.py` (lines 1468-1469). Also, add a server-side log record, including the exception and stack trace, to facilitate debugging.

**Implementation steps:**
- In the `except Exception as e:` block at line 1468, replace the current `return` with:
  - A call to `logging.exception()` to log the full exception (message and traceback).
  - A generic user-facing message, e.g., `"Failed to read file."`.
- No new imports are needed (since `import logging` is already present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
