### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/theme_service.py
+++ b/theme_service.py
@@ -75,7 +75,8 @@ class ThemeService:
         try:
             data = json.loads(theme_data_str)
         except json.JSONDecodeError as e:
-            return False, f"Invalid JSON: {str(e)}", None
+            logger.error(f"Invalid JSON when validating theme: {e}")
+            return False, "Invalid theme file format.", None
         
         for key in REQUIRED_THEME_KEYS:
             if key not in data:
@@ -153,7 +154,7 @@ class ThemeService:
         except Exception as e:
             session.rollback()
             logger.error(f"Failed to save custom theme: {e}")
-            return False, str(e), None
+            return False, "Failed to save custom theme due to a server error.", None
         finally:
             session.close()
     


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/8](https://github.com/netpersona/Popcorn/security/code-scanning/8)

To fix this problem, we should ensure that error messages returned to the client do not include the details of internal exceptions or stack traces. In practice, this means replacing the error string sent to the client in cases of invalid input or internal failure with a generic message such as "Invalid theme file" (for user errors), or "An internal error occurred" (for unexpected exceptions).

Specifically:
- In `theme_service.py`, update the `validate_theme_json` method to return a generic message when a JSON decode error occurs, rather than including the string of the actual exception.
- In `save_custom_theme`, when an exception occurs, log the full error server-side (as you already do), but return only a generic message to the client.
- In `app.py`'s upload endpoint, no change is needed if the `error` string coming from `ThemeService.save_custom_theme` is now safe and generic.

Required:
- Edit lines in `theme_service.py` where user-facing error strings are constructed (lines 78 and 156) so they no longer include details from internal exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
