### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -984,7 +984,10 @@ def play(movie_id):
         logger.info(f"Returning web_url to client: {result}")
         return jsonify({'success': True, 'message': message, 'web_url': result, 'offset_min': offset_min})
     else:
-        return jsonify({'success': success, 'message': result, 'offset_min': offset_min if success else 0})
+        # Log the detailed error for debugging
+        logger.warning(f"Playback failure for user {current_user.id} ({current_user.username}). Error: {result}")
+        # Return only a generic error to the client
+        return jsonify({'success': False, 'message': "Failed to start playback. Please try again or contact support.", 'offset_min': 0})
 
 @app.route('/api/favorite/<int:movie_id>', methods=['POST'])
 @login_required

--- a/plex_api.py
+++ b/plex_api.py
@@ -141,8 +141,8 @@ class PlexAPI:
                     client.playMedia(movie)
                     logger.info(f"Sent playMedia command to {client.title}")
                 except Exception as e:
-                    logger.error(f"Failed to start playback: {e}")
-                    return False, f"Playback failed: {str(e)}. Make sure your Plex client is responding.", 0
+                    logger.error(f"Failed to start playback: {e}", exc_info=True)
+                    return False, "Playback failed to start. Please check your Plex client and try again.", 0
                 
                 if offset_ms > 0:
                     import time


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/4](https://github.com/netpersona/Popcorn/security/code-scanning/4)

To fix this issue, we must ensure that any exceptions or failure details that could reveal internal server, implementation, or system details are not sent directly to the client. Instead, return a generic error message to the client, while ensuring detailed logs are kept server-side for debugging.

Concretely:
- In `plex_api.py`, instead of returning a string with the exception details (`str(e)`) in the result tuple, log the exception and return a generic error message for the API client.
- In `app.py` (the `play` function), if `success` is `False`, return only a safe, non-revealing message in the `'message'` key that does not include exception details.

You only need to change the logic handling errors in `plex_api.py` for playback, and how these are relayed to users in `app.py`. Only edit lines shown in code snippets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
