### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -390,11 +390,12 @@ class UpdateManager:
             return {'success': True, 'backup_path': backup_path}
             
         except Exception as e:
-            logger.error(f"Update failed: {e}")
+            logger.error(f"Update failed: {e}", exc_info=True)
             report('Error', str(e), 0)
             
             if backup_path:
                 logger.info("Attempting to restore from backup...")
                 self.restore_database(backup_path)
             
-            return {'success': False, 'error': str(e), 'backup_path': backup_path}
+            # Do not expose internal error details to the user
+            return {'success': False, 'error': "An internal error has occurred.", 'backup_path': backup_path}


### PR DESCRIPTION
Potential fix for [https://github.com/netpersona/Popcorn/security/code-scanning/6](https://github.com/netpersona/Popcorn/security/code-scanning/6)

To fix the issue, we should prevent the full text of exceptions from being returned to the user in the API response. Instead, log the exception server-side, and return only a generic error message. This involves:

- Changing `perform_update()` in `updater.py` to return a non-specific message such as `"An internal error has occurred"` instead of `str(e)`, in its `'error'` field.
- Logging the actual exception (and stack trace) server-side with `logger.error()` as is currently done.
- No functionality changes are required, only the structure of error messages sent to the client.
- Only modify code in the region shown, so do not alter logging setup or authentication logic.
- Ensure that backup details (`backup_path`) continue to flow as before.

No new imports are required as logging is already imported and used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
