### PR TITLE
Fix plex_server attribute reference - should be plex

### DIFF
--- a/app.py
+++ b/app.py
@@ -1112,8 +1112,8 @@ def settings():
                 logger.info("Plex API reconnected with new settings")
                 
                 # Capture and store the Plex server's machine identifier
-                if plex_api.plex_server:
-                    machine_id = plex_api.plex_server.machineIdentifier
+                if plex_api.plex:
+                    machine_id = plex_api.plex.machineIdentifier
                     settings_obj.plex_machine_identifier = machine_id
                     db_session.commit()
                     logger.info(f"Stored Plex machine identifier: {machine_id}")


### PR DESCRIPTION
The PlexAPI class uses self.plex not self.plex_server. This fixes the error: 'PlexAPI' object has no attribute 'plex_server' when saving the Plex Connection settings